### PR TITLE
Different alignment of content in a cells

### DIFF
--- a/SimplePDF/SimplePDF.swift
+++ b/SimplePDF/SimplePDF.swift
@@ -407,8 +407,18 @@ open class SimplePDF {
                     return 100 // default which should never be use, because either columnWidth, or columnsWidths is set
                 }()
                 
+                let currentContentAlignment = { () -> ContentAlignment in
+                    if let a = tableDefinition?.alignments {
+                        if a.count > j {
+                            return a[j]
+                        }
+                    }
+                    
+                    return alignment
+                }()
+                
                 let frame = CGRect(x: newOriginX, y: newOriginY, width: currentColumnWidth, height: rowHeight)
-                drawTextInCell(frame, text: dataArray[i][j] as NSString, alignment: alignment, font: currentFont, textColor: currentTextColor)
+                drawTextInCell(frame, text: dataArray[i][j] as NSString, alignment: currentContentAlignment, font: currentFont, textColor: currentTextColor)
             }
         }
         


### PR DESCRIPTION
Added content alignment from the table definition. If the definition of the table is not defined, then the content equalization is taken from the property transferred to the function. Sorry for the repeat.